### PR TITLE
fix(formatter): recompute pipe table widths after shrink

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ In Vim, filter the current buffer through the formatter:
 
 ## 3. Formatting
 
-| Pass            | Behavior                                     |
-| --------------- | -------------------------------------------- |
-| Heading numbers | Numbers ATX headings from h2 by default.     |
-| Heading spacing | Keeps one blank line around headings.        |
-| Tables          | Aligns pipe tables, including CJK width 2.   |
-| EOF newline     | Keeps exactly one final newline.             |
+| Pass            | Behavior                                   |
+| --------------- | ------------------------------------------ |
+| Heading numbers | Numbers ATX headings from h2 by default.   |
+| Heading spacing | Keeps one blank line around headings.      |
+| Tables          | Aligns pipe tables, including CJK width 2. |
+| EOF newline     | Keeps exactly one final newline.           |
 
 Useful options:
 

--- a/docs/behavior-decisions.md
+++ b/docs/behavior-decisions.md
@@ -20,6 +20,12 @@ plan, not silently folded into compatibility work.
   ATX headings to exactly one blank line when a neighboring line exists. It
   skips document start/end boundaries and ignores headings inside fenced code
   blocks.
+- Pipe table alignment: column widths are recomputed from current header and
+  body cell contents. Separator dash lengths preserve alignment markers and
+  column count, but do not keep stale wider padding after cell text shrinks.
+  Emitted separator cells keep enough dash width to remain recognizable as
+  separators on later passes: unaligned columns use width 3, left and right
+  aligned columns use width 4, and centered columns use width 5.
 
 ## 2. Future Release Path
 

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -3,6 +3,7 @@ package formatter
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -46,6 +47,44 @@ func TestFormatTablesUsesDisplayWidth(t *testing.T) {
 	want := "| Name | Value |\n| ---- | ----- |\n| 日本 | 1     |\n| Go   | 20    |\n"
 	if got := FormatTables(input); got != want {
 		t.Fatalf("FormatTables display-width mismatch\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
+func TestFormatTablesRecomputesShorterColumnWidths(t *testing.T) {
+	input := "| Name      | Value |\n| --------- | ----- |\n| A         | 1     |\n| B         | 2     |\n"
+	want := "| Name | Value |\n| ---- | ----- |\n| A    | 1     |\n| B    | 2     |\n"
+	if got := FormatTables(input); got != want {
+		t.Fatalf("FormatTables shorter-column-width mismatch\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
+func TestFormatTablesKeepsAlignedSeparatorsRecognizableAfterShrink(t *testing.T) {
+	input := "| A          | B          | C          |\n| :--------- | :--------: | ---------: |\n| x          | y          | z          |\n"
+	want := "| A    | B     | C    |\n| :--- | :---: | ---: |\n| x    | y     | z    |\n"
+	if got := FormatTables(input); got != want {
+		t.Fatalf("FormatTables aligned shrink mismatch\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
+func TestFormatTablesKeepsTrailingAlignedSeparatorColumnsRecognizable(t *testing.T) {
+	input := "| A | B | C |\n| --- | :--- | :---: | ---: |\n| x | y | z | q |\n"
+	want := "| A   | B    | C     |      |\n| --- | :--- | :---: | ---: |\n| x   | y    | z     | q    |\n"
+	if got := FormatTables(input); got != want {
+		t.Fatalf("FormatTables trailing aligned separator mismatch\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
+func TestFormatTablesReformatsAlignedShrinkOutput(t *testing.T) {
+	input := "| A          | B          | C          |\n| :--------- | :--------: | ---------: |\n| x          | y          | z          |\n"
+	formatted := FormatTables(input)
+	if got := FormatTables(formatted); got != formatted {
+		t.Fatalf("FormatTables aligned shrink idempotence mismatch\nwant:\n%s\ngot:\n%s", formatted, got)
+	}
+
+	expanded := strings.Replace(formatted, "| x    | y     | z    |", "| longer | y | z |", 1)
+	want := "| A      | B     | C    |\n| :----- | :---: | ---: |\n| longer | y     | z    |\n"
+	if got := FormatTables(expanded); got != want {
+		t.Fatalf("FormatTables aligned shrink recompute mismatch\nwant:\n%s\ngot:\n%s", want, got)
 	}
 }
 

--- a/internal/formatter/table.go
+++ b/internal/formatter/table.go
@@ -41,6 +41,9 @@ func formatTableBlock(block []string) []string {
 		for len(widths) < len(cells) {
 			widths = append(widths, 3)
 		}
+		if i == 1 {
+			continue
+		}
 		for j, cell := range cells {
 			width := displayWidth(cell)
 			if width > widths[j] {
@@ -54,6 +57,7 @@ func formatTableBlock(block []string) []string {
 	for len(aligns) < len(widths) {
 		aligns = append(aligns, "---")
 	}
+	applySeparatorMinimumWidths(widths, aligns)
 
 	formatted := make([]string, len(block))
 	for i, row := range rows {
@@ -64,6 +68,26 @@ func formatTableBlock(block []string) []string {
 		formatted[i] = formatDataRow(row, widths)
 	}
 	return formatted
+}
+
+func applySeparatorMinimumWidths(widths []int, aligns []string) {
+	for i := range widths {
+		if minimum := separatorMinimumWidth(aligns[i]); widths[i] < minimum {
+			widths[i] = minimum
+		}
+	}
+}
+
+func separatorMinimumWidth(align string) int {
+	// isTableSeparator requires at least three dashes after alignment colons are stripped.
+	switch align {
+	case ":--", "--:":
+		return 4
+	case ":-:":
+		return 5
+	default:
+		return 3
+	}
 }
 
 func splitTableRow(line string) []string {


### PR DESCRIPTION
## Summary

- Recompute pipe table widths from current header and body cells so stale separator padding does not keep columns wide after text shrinks.
- Preserve parseable separator output for unaligned, left-aligned, centered, and right-aligned columns.
- Document the table alignment width contract.

## Verification

- nix develop .#ci --command go test ./internal/formatter -count=1
- nix fmt
- nix develop .#ci --command go test ./...
- nix flake check --print-build-logs
- nix build --print-build-logs
